### PR TITLE
fix(security): harden secrets and apply rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,23 @@
-# Minimal .env for development
+# Myths and Legends API - Environment Configuration
 # Copy to .env: cp .env.example .env
 
-# Database (required for Docker)
+# Security (required)
+# Generate with: python -c 'import secrets; print(secrets.token_urlsafe(32))'
+SECRET_KEY=
+
+# Database (required)
 POSTGRES_HOST=db
 POSTGRES_USER=myths
-POSTGRES_PASSWORD=myths
+POSTGRES_PASSWORD=
 POSTGRES_DB=myths
 
-# Admin user (optional, has defaults)
+# Admin user (required)
 FIRST_SUPERUSER=admin@example.com
-FIRST_SUPERUSER_PASSWORD=admin123
+FIRST_SUPERUSER_PASSWORD=
 
 # Server (optional, has defaults)
 SERVER_HOST=http://localhost
 PROJECT_NAME="Myths and Legends API"
-
-# Security (optional, auto-generated if not set)
-# SECRET_KEY=your-secret-key-change-in-production
 
 # CORS (optional)
 BACKEND_CORS_ORIGINS=["http://localhost:8080"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Run tests with pytest
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test_db
+          SECRET_KEY: ${{ secrets.TEST_SECRET_KEY || 'ci-test-secret-key-not-for-production' }}
+          POSTGRES_PASSWORD: test
+          FIRST_SUPERUSER_PASSWORD: ${{ secrets.TEST_FIRST_SUPERUSER_PASSWORD || 'ci-test-superuser-password' }}
         run: |
           pytest -v --tb=short --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=68
 
@@ -122,8 +125,16 @@ jobs:
           docker build -t myths-and-legends-api:${{ github.sha }} .
 
       - name: Run container health check
+        env:
+          SECRET_KEY: ${{ secrets.TEST_SECRET_KEY || 'ci-test-secret-key-not-for-production' }}
+          POSTGRES_PASSWORD: ci-test-postgres-password
+          FIRST_SUPERUSER_PASSWORD: ${{ secrets.TEST_FIRST_SUPERUSER_PASSWORD || 'ci-test-superuser-password' }}
         run: |
-          docker run -d --name test-container -p 8080:8080 myths-and-legends-api:${{ github.sha }}
+          docker run -d --name test-container -p 8080:8080 \
+            -e SECRET_KEY="$SECRET_KEY" \
+            -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+            -e FIRST_SUPERUSER_PASSWORD="$FIRST_SUPERUSER_PASSWORD" \
+            myths-and-legends-api:${{ github.sha }}
           sleep 10
           docker logs test-container
           docker stop test-container

--- a/app/api/common/middleware/rate_limiter.py
+++ b/app/api/common/middleware/rate_limiter.py
@@ -6,6 +6,7 @@ Uses slowapi for rate limiting with configurable limits per endpoint.
 
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
 from starlette.requests import Request
 
@@ -23,8 +24,11 @@ def rate_limit_key_func(request: Request) -> str:
     return get_remote_address(request)
 
 
-# Initialize limiter
-limiter = Limiter(key_func=rate_limit_key_func)
+# Initialize limiter with default rate limit for all endpoints
+limiter = Limiter(
+    key_func=rate_limit_key_func,
+    default_limits=[f"{settings.RATE_LIMIT_PER_MINUTE}/minute"],
+)
 
 
 # Custom rate limit exceeded response
@@ -45,9 +49,9 @@ def setup_rate_limiter(app):
     """
     Configure rate limiting on the FastAPI app.
 
-    - Login endpoint: Limited to prevent brute force attacks
-    - Password recovery: Limited to prevent abuse
-    - All other endpoints: Use default limit from settings
+    - All endpoints: Default limit from settings (60/min)
+    - Login/password recovery: Stricter limit from settings (10/min)
     """
+    app.add_middleware(SlowAPIMiddleware)
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, rate_limit_exception_handler)

--- a/app/api/v1/domains/auth/endpoints/auth.py
+++ b/app/api/v1/domains/auth/endpoints/auth.py
@@ -6,6 +6,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from app.api.common.middleware.rate_limiter import limiter
 from app.api.v1.domains.users.services.user import user as user_crud
 from app.api.v1.domains.users.models.user import User as UserModel
 from app.api.v1.domains.users.schemas.user import User as UserSchema
@@ -70,6 +71,7 @@ class LoginRequest(BaseModel):
         }
     },
 )
+@limiter.limit(f"{settings.RATE_LIMIT_AUTH_PER_MINUTE}/minute")
 async def login_access_token(
     db: Session = Depends(get_db),
     form_data: OAuth2PasswordRequestForm = Depends(),
@@ -127,6 +129,7 @@ async def get_current_user_info(
         404: {"description": "User not found"},
     },
 )
+@limiter.limit(f"{settings.RATE_LIMIT_AUTH_PER_MINUTE}/minute")
 async def recover_password(
     email: str = Path(
         ..., description="User email address", examples=["user@example.com"]

--- a/app/api/v1/domains/auth/endpoints/auth.py
+++ b/app/api/v1/domains/auth/endpoints/auth.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime
 from typing import Any
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -73,6 +73,7 @@ class LoginRequest(BaseModel):
 )
 @limiter.limit(f"{settings.RATE_LIMIT_AUTH_PER_MINUTE}/minute")
 async def login_access_token(
+    request: Request,
     db: Session = Depends(get_db),
     form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> dict[str, Any]:
@@ -131,6 +132,7 @@ async def get_current_user_info(
 )
 @limiter.limit(f"{settings.RATE_LIMIT_AUTH_PER_MINUTE}/minute")
 async def recover_password(
+    request: Request,
     email: str = Path(
         ..., description="User email address", examples=["user@example.com"]
     ),

--- a/app/api/v1/entities/endpoints/entities.py
+++ b/app/api/v1/entities/endpoints/entities.py
@@ -76,6 +76,7 @@ async def search_entities(
         str,
         Query(
             min_length=1,
+            max_length=200,
             description="Search term (searches name, description, and origin)",
             examples=["Zeus", "underworld", "god of thunder"],
         ),

--- a/app/api/v1/entities/endpoints/locations.py
+++ b/app/api/v1/entities/endpoints/locations.py
@@ -24,7 +24,11 @@ async def list_locations(
     db: Annotated[Session, Depends(get_db)],
     department: Annotated[
         str | None,
-        Query(description="Filter by department", examples=["Cundinamarca", "Oaxaca"]),
+        Query(
+            max_length=200,
+            description="Filter by department",
+            examples=["Cundinamarca", "Oaxaca"],
+        ),
     ] = None,
 ):
     """List all locations, optionally filtered by department."""
@@ -45,7 +49,8 @@ async def list_locations(
 async def get_location_by_department(
     db: Annotated[Session, Depends(get_db)],
     department: Annotated[
-        str, Path(description="Department name", examples=["Cundinamarca"])
+        str,
+        Path(max_length=200, description="Department name", examples=["Cundinamarca"]),
     ],
 ):
     """Get all locations in a specific department."""

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,6 @@
-import secrets
 from typing import Any, List, Optional, Union
 
-from pydantic import EmailStr, PostgresDsn, field_validator
+from pydantic import EmailStr, PostgresDsn, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -16,7 +15,7 @@ class Settings(BaseSettings):
 
     API_VERSION: str = "1"
     APP_PORT: int = 8080
-    SECRET_KEY: str = secrets.token_urlsafe(32)
+    SECRET_KEY: str
     # 60 minutes * 24 hours * 8 days = 8 days
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 8
     SERVER_HOST: str = "http://localhost"
@@ -33,6 +32,23 @@ class Settings(BaseSettings):
     RATE_LIMIT_PER_MINUTE: int = 60
     RATE_LIMIT_AUTH_PER_MINUTE: int = 10
 
+    @model_validator(mode="after")
+    def validate_required_secrets(self) -> "Settings":
+        if not self.SECRET_KEY:
+            raise ValueError(
+                "SECRET_KEY is required. Set it via env var or .env file. "
+                "Generate one with: python -c 'import secrets; print(secrets.token_urlsafe(32))'"
+            )
+        if not self.POSTGRES_PASSWORD:
+            raise ValueError(
+                "POSTGRES_PASSWORD is required. Set it via env var or .env file."
+            )
+        if not self.FIRST_SUPERUSER_PASSWORD:
+            raise ValueError(
+                "FIRST_SUPERUSER_PASSWORD is required. Set it via env var or .env file."
+            )
+        return self
+
     @field_validator("BACKEND_CORS_ORIGINS", mode="before")
     @classmethod
     def assemble_cors_origins(cls, v: Union[str, List[str]]) -> Union[List[str], str]:
@@ -46,7 +62,7 @@ class Settings(BaseSettings):
 
     POSTGRES_HOST: str = "localhost"
     POSTGRES_USER: str = "myths"
-    POSTGRES_PASSWORD: str = "myths"
+    POSTGRES_PASSWORD: str
     POSTGRES_DB: str = "myths"
     SQLALCHEMY_DATABASE_URI: Optional[PostgresDsn] = None
 
@@ -58,9 +74,9 @@ class Settings(BaseSettings):
         values = info.data
         return PostgresDsn.build(
             scheme="postgresql",
-            username=values.get("POSTGRES_USER", "myths"),
-            password=values.get("POSTGRES_PASSWORD", "myths"),
-            host=values.get("POSTGRES_HOST", "localhost"),
+            username=values.get("POSTGRES_USER"),
+            password=values.get("POSTGRES_PASSWORD"),
+            host=values.get("POSTGRES_HOST"),
             path=f"{values.get('POSTGRES_DB') or 'myths'}",
         )
 
@@ -88,7 +104,7 @@ class Settings(BaseSettings):
 
     EMAIL_TEST_USER: EmailStr = "test@example.com"  # type: ignore
     FIRST_SUPERUSER: EmailStr = "admin@example.com"  # type: ignore
-    FIRST_SUPERUSER_PASSWORD: str = "admin123"
+    FIRST_SUPERUSER_PASSWORD: str
     USERS_OPEN_REGISTRATION: bool = False
 
 


### PR DESCRIPTION
## Summary
- Make `SECRET_KEY`, `POSTGRES_PASSWORD`, and `FIRST_SUPERUSER_PASSWORD` required — no more hardcoded defaults that regenerate or expose credentials
- Apply rate limiting to ALL endpoints via `SlowAPIMiddleware` (was configured but never applied)
- Add rate limit decorators to login and password recovery endpoints (10/min)
- Add `max_length=200` validation to search and location query parameters

## Fixes
- #44 — SECRET_KEY no longer regenerates on restart
- #47 — Hardcoded default credentials removed, validation added
- #45 — Rate limiting now actually applied to endpoints
- #15 — Search query parameters now bounded
- #33 — Already implemented, verified in code
- #37 — Already implemented, verified in code

## Test plan
- [ ] App fails to start without `SECRET_KEY` in `.env` (clear error message)
- [ ] Login endpoint returns 429 after 10 rapid requests
- [ ] Search endpoint rejects queries > 200 characters