### PR TITLE
fix(security): return JSONResponse from rate limit exception handler

### DIFF
--- a/app/api/common/middleware/rate_limiter.py
+++ b/app/api/common/middleware/rate_limiter.py
@@ -9,6 +9,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
 from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from app.core.config import settings
 
@@ -34,15 +35,18 @@ limiter = Limiter(
 # Custom rate limit exceeded response
 async def rate_limit_exception_handler(
     request: Request, exc: RateLimitExceeded
-) -> dict:
+) -> JSONResponse:
     """Return a JSON response for rate limit exceeded errors."""
-    return {
-        "detail": {
-            "message": f"Rate limit exceeded. {exc.detail}",
-            "type": "rate_limit_exceeded",
-            "retry_after": getattr(exc, "retry_after", None),
-        }
-    }
+    return JSONResponse(
+        status_code=429,
+        content={
+            "detail": {
+                "message": f"Rate limit exceeded. {exc.detail}",
+                "type": "rate_limit_exceeded",
+                "retry_after": getattr(exc, "retry_after", None),
+            }
+        },
+    )
 
 
 def setup_rate_limiter(app):


### PR DESCRIPTION
## Summary
`rate_limit_exception_handler` (added in #49) returned a plain `dict` instead of a `Response`. Starlette's exception middleware tries to call the handler's return value as an ASGI response callable — so every actual 429 crashed with `TypeError: 'dict' object is not callable` instead of returning a rate-limit response.

## Why it wasn't caught
#49 had no automated test that actually triggered the exceeded-limit path. It surfaced while reviewing #50 (fix/testing), whose test suite calls `/login` enough times in a single run to trip the new 10/min limit, producing this exact crash across a cascade of unrelated tests.

## Fix
Wrap the response in `starlette.responses.JSONResponse` with `status_code=429`, matching the handler's declared intent.