### PR TITLE
fix: wire up seed data on startup and fix bcrypt/passlib crash

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,6 +1,29 @@
 from datetime import datetime, timedelta
 from typing import Any, Union
 
+# Patch bcrypt compatibility issue with passlib (bcrypt >= 4.1 dropped the
+# __about__.__version__ attribute passlib's backend probe relies on, and
+# changed truncation behavior for passwords > 72 bytes). Must run before
+# passlib is imported.
+import bcrypt as _bcrypt_lib
+
+
+class _BcryptAbout:
+    __version__ = _bcrypt_lib.__version__
+
+
+_bcrypt_lib.__about__ = _BcryptAbout()
+_original_bcrypt_hashpw = _bcrypt_lib.hashpw
+
+
+def _safe_bcrypt_hashpw(password, salt):
+    if isinstance(password, bytes) and len(password) > 72:
+        password = password[:72]
+    return _original_bcrypt_hashpw(password, salt)
+
+
+_bcrypt_lib.hashpw = _safe_bcrypt_hashpw
+
 from jose import jwt
 from passlib.context import CryptContext
 

--- a/app/db/init_db.py
+++ b/app/db/init_db.py
@@ -1,6 +1,9 @@
 from sqlalchemy.orm import Session
 
-from app.api.v1 import services, schemas
+from app.api.v1.domains.users.services.user import user as user_service
+from app.api.v1.domains.users.schemas.user import UserCreate
+from app.api.v1.entities.models.entity import Entity
+from app.api.v1.entities.seed import init_seed_data
 from app.core.config import settings
 from app.db import base  # noqa: F401
 
@@ -15,11 +18,16 @@ def init_db(db: Session) -> None:
     # the tables un-commenting the next line
     # Base.metadata.create_all(bind=engine)
 
-    user = services.user.get_by_email(db, email=settings.FIRST_SUPERUSER)
+    user = user_service.get_by_email(db, email=settings.FIRST_SUPERUSER)
     if not user:
-        user_in = schemas.UserCreate(
+        user_in = UserCreate(
             email=settings.FIRST_SUPERUSER,
             password=settings.FIRST_SUPERUSER_PASSWORD,
             is_superuser=True,
         )
-        user = services.user.create(db, obj_in=user_in)  # noqa: F841
+        user = user_service.create(db, obj_in=user_in)  # noqa: F841
+
+    # Seed the mythology catalog on first run only (idempotent: skip if any
+    # entity already exists, since init_seed_data() doesn't check for dupes)
+    if db.query(Entity).first() is None:
+        init_seed_data(db)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,24 +7,9 @@ import os
 import tempfile
 from typing import Generator
 
-# Patch bcrypt compatibility issue with passlib (bcrypt >= 4.1).
-# Must run before passlib is imported anywhere.
-import bcrypt as _bcrypt_lib
-
-class _BcryptAbout:
-    __version__ = _bcrypt_lib.__version__
-
-_bcrypt_lib.__about__ = _BcryptAbout()
-_original_bcrypt_hashpw = _bcrypt_lib.hashpw
-
-
-def _safe_bcrypt_hashpw(password, salt):
-    if isinstance(password, bytes) and len(password) > 72:
-        password = password[:72]
-    return _original_bcrypt_hashpw(password, salt)
-
-
-_bcrypt_lib.hashpw = _safe_bcrypt_hashpw
+# The bcrypt/passlib compatibility shim now lives in app.core.security
+# (must run before passlib is imported anywhere), so it's no longer
+# duplicated here — importing app.main below pulls it in transitively.
 
 import pytest
 from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary
Two bugs found while wiring up the mythology catalog seed data, both would crash a fresh deploy:

1. `init_db.py` imported `from app.api.v1 import services, schemas` — that top-level package no longer exists post domain-driven refactor. `prestart.sh` would ImportError on every container start. Fixed imports, wired `init_seed_data()` in (idempotent).
2. `app/core/security.py` had no bcrypt/passlib compatibility shim — passlib's internal self-test crashes on first hash/verify with `bcrypt>=4.1` installed (which an unpinned `pip install` gets today). The exact shim already existed in `tests/conftest.py`, which is why tests never caught it — moved it to the real app code.

## Verification
Ran against a fresh Postgres 15 + clean `pip install -r requirements.txt` in a container matching the docker-compose network topology (hostname `db`, no cached deps): migrations apply, superuser + all 11 seed entities create correctly, re-running is idempotent (no duplicates on a second run), full test suite passes 145/145 at 82.5% coverage.