### PR TITLE
fix: critical security issues (unauthenticated writes, broken password reset, rate-limit bypass)

### DIFF
--- a/app/api/common/middleware/rate_limiter.py
+++ b/app/api/common/middleware/rate_limiter.py
@@ -17,11 +17,18 @@ from app.core.config import settings
 def rate_limit_key_func(request: Request) -> str:
     """
     Get the rate limit key based on client IP.
-    Falls back to 'unknown' if IP cannot be determined.
+
+    Only honors X-Forwarded-For when the directly connecting peer is a
+    trusted proxy (settings.TRUSTED_PROXY_IPS); otherwise any client could
+    set an arbitrary value and get a fresh rate-limit bucket per request,
+    bypassing brute-force protection entirely. Falls back to the real
+    connecting IP address (via slowapi's get_remote_address) by default.
     """
-    forwarded = request.headers.get("X-Forwarded-For")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
+    client_host = request.client.host if request.client else None
+    if client_host and client_host in settings.TRUSTED_PROXY_IPS:
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
     return get_remote_address(request)
 
 

--- a/app/api/v1/domains/auth/endpoints/auth.py
+++ b/app/api/v1/domains/auth/endpoints/auth.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime
 from typing import Any
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request
+from fastapi import APIRouter, Depends, HTTPException, Path, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -31,6 +31,23 @@ class LoginRequest(BaseModel):
         ..., description="User email address", examples=["user@example.com"]
     )
     password: str = Field(..., description="User password", examples=["SecureP@ss123"])
+
+
+class PasswordReset(BaseModel):
+    """Password reset request schema."""
+
+    token: str = Field(
+        ...,
+        description="Password recovery token",
+        examples=["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."],
+    )
+    new_password: str = Field(
+        ...,
+        min_length=8,
+        max_length=100,
+        description="New password (min 8 characters)",
+        examples=["NewSecureP@ss123"],
+    )
 
 
 @router.post(
@@ -126,8 +143,7 @@ async def get_current_user_info(
     summary="Password Recovery",
     description="Initiate password recovery by sending a reset email to the user.",
     responses={
-        200: {"description": "Password recovery email sent"},
-        404: {"description": "User not found"},
+        200: {"description": "Password recovery email sent, if the account exists"},
     },
 )
 @limiter.limit(f"{settings.RATE_LIMIT_AUTH_PER_MINUTE}/minute")
@@ -141,20 +157,21 @@ async def recover_password(
     """
     Password Recovery.
 
-    Rate limited to prevent abuse.
+    Rate limited to prevent abuse. Always returns a generic 200 response
+    regardless of whether the email is registered, to avoid leaking which
+    accounts exist (user enumeration).
     """
     user = user_crud.get_by_email(db, email=email)
 
-    if not user:
-        raise HTTPException(
-            status_code=404,
-            detail="The user with this username does not exist in the system.",
+    if user:
+        password_reset_token = generate_password_reset_token(email=email)
+        send_reset_password_email(
+            email_to=user.email, email=email, token=password_reset_token
         )
-    password_reset_token = generate_password_reset_token(email=email)
-    send_reset_password_email(
-        email_to=user.email, email=email, token=password_reset_token
-    )
-    return {"msg": "Password recovery email sent"}
+
+    return {
+        "msg": "If an account with that email exists, a password recovery email has been sent"
+    }
 
 
 @router.post(
@@ -167,22 +184,19 @@ async def recover_password(
         404: {"description": "User not found"},
     },
 )
+@limiter.limit(f"{settings.RATE_LIMIT_AUTH_PER_MINUTE}/minute")
 async def reset_password(
-    token: str = Body(
-        ...,
-        description="Password recovery token",
-        examples=["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."],
-    ),
-    new_password: str = Body(
-        ...,
-        description="New password (min 8 characters)",
-        examples=["NewSecureP@ss123"],
-    ),
+    request: Request,
+    password_reset: PasswordReset,
     db: Session = Depends(get_db),
 ) -> dict[str, str]:
     """
     Reset password using a valid recovery token.
+
+    Rate limited to prevent abuse.
     """
+    token = password_reset.token
+    new_password = password_reset.new_password
     email = verify_password_reset_token(token)
     if not email:
         raise HTTPException(status_code=400, detail="Invalid token")

--- a/app/api/v1/domains/countries/endpoints/countries.py
+++ b/app/api/v1/domains/countries/endpoints/countries.py
@@ -10,7 +10,8 @@ from app.api.v1.domains.countries.schemas.country import (
     Country as CountrySchema,
 )
 from app.api.v1.domains.countries.services.country import country as country_service
-from app.api.v1.shared.deps import get_db
+from app.api.v1.shared.deps import get_db, get_current_active_superuser
+from app.api.v1.domains.users.models.user import User as UserModel
 
 router = APIRouter()
 
@@ -54,10 +55,12 @@ async def list_countries(
     response_model=CountrySchema,
     status_code=201,
     summary="Create Country",
-    description="Create a new country in the system.",
+    description="Create a new country in the system. Requires superuser privileges.",
     responses={
         201: {"description": "Country successfully created"},
         400: {"description": "Invalid input data"},
+        401: {"description": "Unauthorized - No valid token provided"},
+        403: {"description": "Forbidden - User is not a superuser"},
     },
 )
 async def add_country(
@@ -67,8 +70,9 @@ async def add_country(
         description="Country data to create",
         examples=[{"name": "Nigeria", "status": True}],
     ),
+    current_user: UserModel = Depends(get_current_active_superuser),
 ) -> CountrySchema:
-    """Create a new country."""
+    """Create a new country. Requires superuser privileges."""
     country_created = country_service.create(db, obj_in=country)
     return country_created
 
@@ -108,10 +112,12 @@ async def get_country(
     "/{country_id}",
     response_model=CountrySchema,
     summary="Update Country",
-    description="Update an existing country by its ID.",
+    description="Update an existing country by its ID. Requires superuser privileges.",
     responses={
         200: {"description": "Country successfully updated"},
         404: {"description": "Country not found"},
+        401: {"description": "Unauthorized - No valid token provided"},
+        403: {"description": "Forbidden - User is not a superuser"},
     },
 )
 async def update_country(
@@ -119,8 +125,9 @@ async def update_country(
     db: Session = Depends(get_db),
     country_id: int = Path(..., description="Country ID", examples=[1], gt=0),
     country_in: CountryUpdate = Body(..., description="Updated country data"),
+    current_user: UserModel = Depends(get_current_active_superuser),
 ) -> CountrySchema:
-    """Update a country."""
+    """Update a country. Requires superuser privileges."""
     country = country_service.get(db, item_id=country_id)
 
     if not country:
@@ -134,18 +141,21 @@ async def update_country(
     "/{country_id}",
     status_code=204,
     summary="Delete Country",
-    description="Delete a country by its ID.",
+    description="Delete a country by its ID. Requires superuser privileges.",
     responses={
         204: {"description": "Country successfully deleted"},
         404: {"description": "Country not found"},
+        401: {"description": "Unauthorized - No valid token provided"},
+        403: {"description": "Forbidden - User is not a superuser"},
     },
 )
 async def delete_country(
     *,
     db: Session = Depends(get_db),
     country_id: int = Path(..., description="Country ID", examples=[1], gt=0),
+    current_user: UserModel = Depends(get_current_active_superuser),
 ) -> None:
-    """Delete a country."""
+    """Delete a country. Requires superuser privileges."""
     country = country_service.get(db, item_id=country_id)
 
     if not country:

--- a/app/api/v1/entities/endpoints/entities.py
+++ b/app/api/v1/entities/endpoints/entities.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi_pagination import Page, Params, paginate
 from sqlalchemy.orm import Session
 
-from app.api.v1.shared.deps import get_db
+from app.api.v1.shared.deps import get_db, get_current_active_superuser
 from app.api.v1.entities.services import entity, relation
 from app.api.v1.entities.schemas.entity import Entity, EntityCreate, EntityUpdate
 from app.api.v1.entities.schemas.entity_with_relations import (
@@ -12,6 +12,7 @@ from app.api.v1.entities.schemas.entity_with_relations import (
     EntityRelationSummary,
 )
 from app.api.v1.entities.enums import EntityTypeName, CategoryName
+from app.api.v1.domains.users.models.user import User as UserModel
 
 router = APIRouter(prefix="/entities", tags=["entities"])
 
@@ -159,17 +160,20 @@ async def get_entity(
     response_model=Entity,
     status_code=201,
     summary="Create Entity",
-    description="Create a new mythological entity.",
+    description="Create a new mythological entity. Requires superuser privileges.",
     responses={
         201: {"description": "Entity successfully created"},
         400: {"description": "Invalid input data"},
+        401: {"description": "Unauthorized - No valid token provided"},
+        403: {"description": "Forbidden - User is not a superuser"},
     },
 )
 async def create_entity(
     db: Annotated[Session, Depends(get_db)],
     entity_in: EntityCreate,
+    current_user: UserModel = Depends(get_current_active_superuser),
 ):
-    """Create a new entity."""
+    """Create a new entity. Requires superuser privileges."""
     return entity.create(db, obj_in=entity_in)
 
 
@@ -177,18 +181,21 @@ async def create_entity(
     "/{id}",
     response_model=Entity,
     summary="Update Entity",
-    description="Update an existing entity by ID.",
+    description="Update an existing entity by ID. Requires superuser privileges.",
     responses={
         200: {"description": "Entity successfully updated"},
         404: {"description": "Entity not found"},
+        401: {"description": "Unauthorized - No valid token provided"},
+        403: {"description": "Forbidden - User is not a superuser"},
     },
 )
 async def update_entity(
     db: Annotated[Session, Depends(get_db)],
     id: Annotated[int, Path(gt=0, description="Entity ID", examples=[1])],
     entity_in: EntityUpdate,
+    current_user: UserModel = Depends(get_current_active_superuser),
 ):
-    """Update an entity."""
+    """Update an entity. Requires superuser privileges."""
     db_entity = entity.get(db, item_id=id)
     if not db_entity:
         raise HTTPException(status_code=404, detail="Entity not found")
@@ -199,17 +206,20 @@ async def update_entity(
     "/{id}",
     status_code=204,
     summary="Delete Entity",
-    description="Delete an entity by ID.",
+    description="Delete an entity by ID. Requires superuser privileges.",
     responses={
         204: {"description": "Entity successfully deleted"},
         404: {"description": "Entity not found"},
+        401: {"description": "Unauthorized - No valid token provided"},
+        403: {"description": "Forbidden - User is not a superuser"},
     },
 )
 async def delete_entity(
     db: Annotated[Session, Depends(get_db)],
     id: Annotated[int, Path(gt=0, description="Entity ID", examples=[1])],
+    current_user: UserModel = Depends(get_current_active_superuser),
 ):
-    """Delete an entity."""
+    """Delete an entity. Requires superuser privileges."""
     db_entity = entity.get(db, item_id=id)
     if not db_entity:
         raise HTTPException(status_code=404, detail="Entity not found")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -32,6 +32,12 @@ class Settings(BaseSettings):
     RATE_LIMIT_PER_MINUTE: int = 60
     RATE_LIMIT_AUTH_PER_MINUTE: int = 10
 
+    # Trusted proxy IPs allowed to set X-Forwarded-For for rate limiting.
+    # Empty by default - nothing is trusted, so the real connecting IP is
+    # always used unless the connecting peer is explicitly listed here
+    # (e.g. the Traefik reverse proxy IP once deployed).
+    TRUSTED_PROXY_IPS: List[str] = []
+
     @model_validator(mode="after")
     def validate_required_secrets(self) -> "Settings":
         if not self.SECRET_KEY:

--- a/app/main.py
+++ b/app/main.py
@@ -76,9 +76,7 @@ app.add_middleware(SecurityHeadersMiddleware)
 # Set all CORS enabled
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        str(origin).replace("/", "") for origin in settings.BACKEND_CORS_ORIGINS
-    ],
+    allow_origins=[str(origin) for origin in settings.BACKEND_CORS_ORIGINS],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/app/utils.py
+++ b/app/utils.py
@@ -103,6 +103,6 @@ def generate_password_reset_token(email: str) -> str:
 def verify_password_reset_token(token: str) -> Optional[str]:
     try:
         decoded_token = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
-        return decoded_token["email"]
+        return decoded_token["sub"]
     except jwt.JWTError:
         return None

--- a/tests/domains/test_auth.py
+++ b/tests/domains/test_auth.py
@@ -114,17 +114,22 @@ class TestAuthEndpoints:
             )
             assert response.status_code == 200
             data = response.json()
-            assert "Password recovery email sent" in data["msg"]
+            assert "password recovery email has been sent" in data["msg"]
             mock_send.assert_called_once()
 
     def test_password_recovery_user_not_found(self, client: TestClient):
-        """Test password recovery for non-existent user returns 404."""
-        response = client.post(
-            "/api/v1/auth/password-recovery/nonexistent@example.com"
-        )
-        assert response.status_code == 404
-        data = response.json()
-        assert "detail" in data
+        """Test password recovery for non-existent user returns a generic 200
+        response (no user enumeration) instead of leaking a 404."""
+        with patch(
+            "app.api.v1.domains.auth.endpoints.auth.send_reset_password_email"
+        ) as mock_send:
+            response = client.post(
+                "/api/v1/auth/password-recovery/nonexistent@example.com"
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert "msg" in data
+            mock_send.assert_not_called()
 
     def test_reset_password_success(self, client: TestClient, test_user: dict, db: Session):
         """Test resetting password with valid token."""

--- a/tests/domains/test_countries.py
+++ b/tests/domains/test_countries.py
@@ -105,10 +105,11 @@ class TestCountriesEndpoints:
         data = response.json()
         assert len(data) == 2
 
-    def test_create_country(self, client: TestClient):
+    def test_create_country(self, client: TestClient, superuser_headers: dict):
         """Test creating a country."""
         response = client.post(
             "/api/v1/countries/",
+            headers=superuser_headers,
             json={"name": "El Salvador", "status": True},
         )
         assert response.status_code == 201
@@ -134,7 +135,7 @@ class TestCountriesEndpoints:
         data = response.json()
         assert "detail" in data
 
-    def test_update_country(self, client: TestClient, db: Session):
+    def test_update_country(self, client: TestClient, db: Session, superuser_headers: dict):
         """Test updating a country."""
         country = Country(name="Nicaragua", status=True)
         db.add(country)
@@ -142,21 +143,86 @@ class TestCountriesEndpoints:
 
         response = client.put(
             f"/api/v1/countries/{country.id}",
+            headers=superuser_headers,
             json={"name": "Republic of Nicaragua"},
         )
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == "Republic of Nicaragua"
 
-    def test_delete_country(self, client: TestClient, db: Session):
+    def test_delete_country(self, client: TestClient, db: Session, superuser_headers: dict):
         """Test deleting a country."""
         country = Country(name="Costa Rica", status=True)
         db.add(country)
         db.commit()
 
-        response = client.delete(f"/api/v1/countries/{country.id}")
+        response = client.delete(f"/api/v1/countries/{country.id}", headers=superuser_headers)
         assert response.status_code == 204
 
         # Verify deletion
         response = client.get(f"/api/v1/countries/{country.id}")
         assert response.status_code == 404
+
+    def test_create_country_without_auth(self, client: TestClient):
+        """Test creating a country without authentication returns 401."""
+        response = client.post(
+            "/api/v1/countries/",
+            json={"name": "Belize", "status": True},
+        )
+        assert response.status_code == 401
+
+    def test_create_country_as_regular_user(self, client: TestClient, auth_headers: dict):
+        """Test creating a country as non-superuser returns 403."""
+        response = client.post(
+            "/api/v1/countries/",
+            headers=auth_headers,
+            json={"name": "Belize", "status": True},
+        )
+        assert response.status_code == 403
+
+    def test_update_country_without_auth(self, client: TestClient, db: Session):
+        """Test updating a country without authentication returns 401."""
+        country = Country(name="Panama", status=True)
+        db.add(country)
+        db.commit()
+
+        response = client.put(
+            f"/api/v1/countries/{country.id}",
+            json={"name": "Hacked"},
+        )
+        assert response.status_code == 401
+
+    def test_update_country_as_regular_user(
+        self, client: TestClient, db: Session, auth_headers: dict
+    ):
+        """Test updating a country as non-superuser returns 403."""
+        country = Country(name="Panama", status=True)
+        db.add(country)
+        db.commit()
+
+        response = client.put(
+            f"/api/v1/countries/{country.id}",
+            headers=auth_headers,
+            json={"name": "Hacked"},
+        )
+        assert response.status_code == 403
+
+    def test_delete_country_without_auth(self, client: TestClient, db: Session):
+        """Test deleting a country without authentication returns 401."""
+        country = Country(name="Belize", status=True)
+        db.add(country)
+        db.commit()
+
+        response = client.delete(f"/api/v1/countries/{country.id}")
+        assert response.status_code == 401
+
+    def test_delete_country_as_regular_user(
+        self, client: TestClient, db: Session, auth_headers: dict
+    ):
+        """Test deleting a country as non-superuser returns 403."""
+        country = Country(name="Belize", status=True)
+        db.add(country)
+        db.commit()
+
+        response = client.delete(f"/api/v1/countries/{country.id}", headers=auth_headers)
+        assert response.status_code == 403

--- a/tests/domains/test_entities.py
+++ b/tests/domains/test_entities.py
@@ -379,12 +379,13 @@ class TestEntitiesEndpoints:
         data = response.json()
         assert data["detail"] == "Entity not found"
 
-    def test_create_entity(self, client: TestClient, db: Session):
+    def test_create_entity(self, client: TestClient, db: Session, superuser_headers: dict):
         """Test creating an entity."""
         deps = self._seed_dependencies(db)
 
         response = client.post(
             "/api/v1/entities/",
+            headers=superuser_headers,
             json={
                 "name": "Poseidon",
                 "category_id": deps["category_id"],
@@ -399,12 +400,13 @@ class TestEntitiesEndpoints:
         assert data["description"] == "God of the sea"
         assert data["is_active"] is True
 
-    def test_create_entity_minimal(self, client: TestClient, db: Session):
+    def test_create_entity_minimal(self, client: TestClient, db: Session, superuser_headers: dict):
         """Test creating an entity with only required fields."""
         deps = self._seed_dependencies(db)
 
         response = client.post(
             "/api/v1/entities/",
+            headers=superuser_headers,
             json={
                 "name": "Minimal Entity",
                 "category_id": deps["category_id"],
@@ -416,7 +418,7 @@ class TestEntitiesEndpoints:
         assert data["name"] == "Minimal Entity"
         assert data["is_active"] is True
 
-    def test_update_entity(self, client: TestClient, db: Session):
+    def test_update_entity(self, client: TestClient, db: Session, superuser_headers: dict):
         """Test updating an entity."""
         deps = self._seed_dependencies(db)
 
@@ -430,6 +432,7 @@ class TestEntitiesEndpoints:
 
         response = client.put(
             f"/api/v1/entities/{entity.id}",
+            headers=superuser_headers,
             json={"name": "Updated Name", "description": "New description"},
         )
         assert response.status_code == 200
@@ -437,17 +440,18 @@ class TestEntitiesEndpoints:
         assert data["name"] == "Updated Name"
         assert data["description"] == "New description"
 
-    def test_update_entity_not_found(self, client: TestClient):
+    def test_update_entity_not_found(self, client: TestClient, superuser_headers: dict):
         """Test updating a non-existent entity."""
         response = client.put(
             "/api/v1/entities/999",
+            headers=superuser_headers,
             json={"name": "Does Not Exist"},
         )
         assert response.status_code == 404
         data = response.json()
         assert data["detail"] == "Entity not found"
 
-    def test_update_entity_partial(self, client: TestClient, db: Session):
+    def test_update_entity_partial(self, client: TestClient, db: Session, superuser_headers: dict):
         """Test partial update of an entity."""
         deps = self._seed_dependencies(db)
 
@@ -462,6 +466,7 @@ class TestEntitiesEndpoints:
 
         response = client.put(
             f"/api/v1/entities/{entity.id}",
+            headers=superuser_headers,
             json={"is_active": False},
         )
         assert response.status_code == 200
@@ -470,7 +475,7 @@ class TestEntitiesEndpoints:
         assert data["description"] == "Original description"
         assert data["is_active"] is False
 
-    def test_delete_entity(self, client: TestClient, db: Session):
+    def test_delete_entity(self, client: TestClient, db: Session, superuser_headers: dict):
         """Test deleting an entity."""
         deps = self._seed_dependencies(db)
 
@@ -482,18 +487,116 @@ class TestEntitiesEndpoints:
         db.add(entity)
         db.commit()
 
-        response = client.delete(f"/api/v1/entities/{entity.id}")
+        response = client.delete(f"/api/v1/entities/{entity.id}", headers=superuser_headers)
         assert response.status_code == 204
 
         response = client.get(f"/api/v1/entities/{entity.id}")
         assert response.status_code == 404
 
-    def test_delete_entity_not_found(self, client: TestClient):
+    def test_delete_entity_not_found(self, client: TestClient, superuser_headers: dict):
         """Test deleting a non-existent entity."""
-        response = client.delete("/api/v1/entities/999")
+        response = client.delete("/api/v1/entities/999", headers=superuser_headers)
         assert response.status_code == 404
         data = response.json()
         assert data["detail"] == "Entity not found"
+
+    def test_create_entity_without_auth(self, client: TestClient, db: Session):
+        """Test creating an entity without authentication returns 401."""
+        deps = self._seed_dependencies(db)
+
+        response = client.post(
+            "/api/v1/entities/",
+            json={
+                "name": "Unauthorized Entity",
+                "category_id": deps["category_id"],
+                "entity_type_id": deps["entity_type_id"],
+            },
+        )
+        assert response.status_code == 401
+
+    def test_create_entity_as_regular_user(
+        self, client: TestClient, db: Session, auth_headers: dict
+    ):
+        """Test creating an entity as non-superuser returns 403."""
+        deps = self._seed_dependencies(db)
+
+        response = client.post(
+            "/api/v1/entities/",
+            headers=auth_headers,
+            json={
+                "name": "Forbidden Entity",
+                "category_id": deps["category_id"],
+                "entity_type_id": deps["entity_type_id"],
+            },
+        )
+        assert response.status_code == 403
+
+    def test_update_entity_without_auth(self, client: TestClient, db: Session):
+        """Test updating an entity without authentication returns 401."""
+        deps = self._seed_dependencies(db)
+        entity = Entity(
+            name="Original",
+            category_id=deps["category_id"],
+            entity_type_id=deps["entity_type_id"],
+        )
+        db.add(entity)
+        db.commit()
+
+        response = client.put(
+            f"/api/v1/entities/{entity.id}",
+            json={"name": "Hacked"},
+        )
+        assert response.status_code == 401
+
+    def test_update_entity_as_regular_user(
+        self, client: TestClient, db: Session, auth_headers: dict
+    ):
+        """Test updating an entity as non-superuser returns 403."""
+        deps = self._seed_dependencies(db)
+        entity = Entity(
+            name="Original",
+            category_id=deps["category_id"],
+            entity_type_id=deps["entity_type_id"],
+        )
+        db.add(entity)
+        db.commit()
+
+        response = client.put(
+            f"/api/v1/entities/{entity.id}",
+            headers=auth_headers,
+            json={"name": "Hacked"},
+        )
+        assert response.status_code == 403
+
+    def test_delete_entity_without_auth(self, client: TestClient, db: Session):
+        """Test deleting an entity without authentication returns 401."""
+        deps = self._seed_dependencies(db)
+        entity = Entity(
+            name="To Delete",
+            category_id=deps["category_id"],
+            entity_type_id=deps["entity_type_id"],
+        )
+        db.add(entity)
+        db.commit()
+
+        response = client.delete(f"/api/v1/entities/{entity.id}")
+        assert response.status_code == 401
+
+    def test_delete_entity_as_regular_user(
+        self, client: TestClient, db: Session, auth_headers: dict
+    ):
+        """Test deleting an entity as non-superuser returns 403."""
+        deps = self._seed_dependencies(db)
+        entity = Entity(
+            name="To Delete",
+            category_id=deps["category_id"],
+            entity_type_id=deps["entity_type_id"],
+        )
+        db.add(entity)
+        db.commit()
+
+        response = client.delete(f"/api/v1/entities/{entity.id}", headers=auth_headers)
+        assert response.status_code == 403
 
     def test_get_entity_relations(self, client: TestClient, db: Session):
         """Test getting entity relations."""


### PR DESCRIPTION
## Summary
6 issues found by independent security reviews (security-reviewer, secure-code-guardian skills) this session, all verified before fixing:

1. **Critical** — `entities`/`countries` create/update/delete endpoints had zero auth (confirmed: no `Depends(get_current...)` anywhere, and the existing test suite encoded the bug by never sending auth headers on those tests). Now require superuser, per decision.
2. **Critical** — password-reset token verification read the wrong JWT claim (`email` instead of `sub`) — every real reset token raised an uncaught `KeyError` → 500. The success-path test mocked the function, which is why it was never caught.
3. **High** — rate limiter trusted client-supplied `X-Forwarded-For` unconditionally — trivial bypass of login brute-force protection. Now only honored from a configured `TRUSTED_PROXY_IPS` list (empty by default).
4. **Medium** — CORS origin allowlist stripped all `/` characters, silently breaking every configured origin (`https://example.com` → `https:example.com`).
5. **Medium** — `/reset-password/` had no rate limit and accepted raw unvalidated `Body()` params despite its own docstring claiming an 8-char minimum. Now uses a real Pydantic schema + the same rate limit as `/login`.
6. **Medium** — `/password-recovery/{email}` leaked account existence via 404-vs-200. Now always returns 200 with a generic message.

## Test coverage
Added 401/403 tests for all 6 newly-auth-gated write endpoints, updated existing write tests to use `superuser_headers`, updated password-recovery tests for the new always-200 behavior.

## Verification
Independently re-ran the full suite against a fresh Postgres 15 container: **157/157 pass**, 82.5% coverage (up from 145 pre-fix — 12 new tests). `flake8`/`black` clean.