### PR TITLE
fix: double-pagination bug and API consistency (sort validation, locations resource)

### DIFF
--- a/app/api/common/services/base_service.py
+++ b/app/api/common/services/base_service.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 from fastapi.encoders import jsonable_encoder
-from fastapi_pagination.bases import AbstractPage
+from fastapi_pagination.bases import AbstractPage, AbstractParams
 from fastapi_pagination.ext.sqlalchemy import paginate
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -29,8 +29,10 @@ class CRUDBaseService(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         self.model = model
 
     def _build_query(self, relations: List[str] | None = None):
-        """Build a select query with optional eager loading."""
-        stmt = select(self.model)
+        """Build a select query with optional eager loading, ordered by id for
+        stable pagination (without an explicit ORDER BY, offset/limit results
+        are not guaranteed to be stable across concurrent writes)."""
+        stmt = select(self.model).order_by(self.model.id)
         if relations:
             stmt = stmt.options(
                 *[selectinload(getattr(self.model, r)) for r in relations]
@@ -70,11 +72,20 @@ class CRUDBaseService(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         self,
         db: Session,
         relations: List[str] | None = None,
+        *,
+        params: AbstractParams | None = None,
     ) -> AbstractPage:
-        """Get all items with pagination (fastapi-pagination)."""
+        """Get all items with pagination (fastapi-pagination).
+
+        `params` is optional: when omitted, fastapi-pagination resolves it
+        from the request's own page/size query params via its ContextVar
+        (wired up by `add_pagination(app)`). Pass it explicitly when the
+        caller already parsed its own page/size (e.g. because it also has
+        other query params to validate) so the two don't drift out of sync.
+        """
         try:
             stmt = self._build_query(relations)
-            return paginate(db, stmt)
+            return paginate(db, stmt, params)
         except ArgumentError as error:
             raise RelationshipNotFoundException(
                 name=error.args[0].split('"')[1],

--- a/app/api/v1/domains/users/endpoints/users.py
+++ b/app/api/v1/domains/users/endpoints/users.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Path
-from fastapi_pagination import Page, Params, paginate
+from fastapi_pagination import Page, Params
 from sqlalchemy.orm import Session
 
 from app.api.v1.domains.users.models.user import User as UserModel
@@ -12,7 +12,6 @@ from app.api.v1.domains.users.schemas.user import (
 )
 from app.api.v1.domains.users.services.user import user as user_service
 from app.api.v1.shared.deps import get_db, get_current_active_superuser
-from app.api.common.pagination.json_api_page import JsonApiPage
 
 router = APIRouter()
 
@@ -41,8 +40,7 @@ async def get_users(
     current_user: UserModel = Depends(get_current_active_superuser),
 ) -> Any:
     """List all users with pagination and sorting."""
-    users = user_service.get_multi(db, skip=(page - 1) * size, limit=size)
-    return paginate(users, Params(page=page, size=size))
+    return user_service.get_all(db, params=Params(page=page, size=size))
 
 
 @router.post(

--- a/app/api/v1/entities/endpoints/categories.py
+++ b/app/api/v1/entities/endpoints/categories.py
@@ -1,6 +1,9 @@
-from typing import Annotated, List
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi_pagination import Page, Params
+from fastapi_pagination.ext.sqlalchemy import paginate
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.v1.shared.deps import get_db
@@ -13,29 +16,31 @@ router = APIRouter(prefix="/categories", tags=["categories"])
 
 @router.get(
     "/",
-    response_model=List[CategorySchema],
+    response_model=Page[CategorySchema],
     summary="List Categories",
-    description="Retrieve all categories for classifying entities (e.g., Deity, Creature, Place).",
+    description="Retrieve a paginated list of categories for classifying entities (e.g., Deity, Creature, Place).",
     responses={
         200: {"description": "Successful retrieval of categories"},
     },
 )
 async def list_categories(
     db: Annotated[Session, Depends(get_db)],
+    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    size: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 20,
     sort: Annotated[
-        str | None, Query(description="Sort field", examples=["name", "id"])
+        Literal["name", "id"],
+        Query(description="Sort field", examples=["name", "id"]),
     ] = "name",
     order: Annotated[
         str, Query(description="Sort order (asc, desc)", examples=["asc", "desc"])
     ] = "asc",
 ):
-    """List all categories."""
-    categories = db.query(Category).all()
-
-    # Sort results
-    if order.lower() == "desc":
-        return sorted(categories, key=lambda x: getattr(x, sort, x.id), reverse=True)
-    return sorted(categories, key=lambda x: getattr(x, sort, x.id))
+    """List all categories, paginated and sorted at the database level."""
+    sort_column = getattr(Category, sort)
+    stmt = select(Category).order_by(
+        sort_column.desc() if order.lower() == "desc" else sort_column.asc()
+    )
+    return paginate(db, stmt, Params(page=page, size=size))
 
 
 @router.get(

--- a/app/api/v1/entities/endpoints/entities.py
+++ b/app/api/v1/entities/endpoints/entities.py
@@ -1,7 +1,7 @@
 from typing import Annotated, List
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
-from fastapi_pagination import Page, Params, paginate
+from fastapi_pagination import Page, Params
 from sqlalchemy.orm import Session
 
 from app.api.v1.shared.deps import get_db, get_current_active_superuser
@@ -51,15 +51,13 @@ async def list_entities(
     order: Annotated[str, Query(description="Sort order (asc, desc)")] = "asc",
 ):
     """List all entities with optional filters and pagination."""
-    entities = entity.get_multi(
+    return entity.get_paginated(
         db,
         entity_type=entity_type,
         category=category,
         is_active=is_active,
-        skip=(page - 1) * size,
-        limit=size,
+        params=Params(page=page, size=size),
     )
-    return paginate(entities, Params(page=page, size=size))
 
 
 @router.get(

--- a/app/api/v1/entities/endpoints/entity_types.py
+++ b/app/api/v1/entities/endpoints/entity_types.py
@@ -1,6 +1,9 @@
-from typing import Annotated, List
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi_pagination import Page, Params
+from fastapi_pagination.ext.sqlalchemy import paginate
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.v1.shared.deps import get_db
@@ -13,29 +16,31 @@ router = APIRouter(prefix="/entity-types", tags=["entity-types"])
 
 @router.get(
     "/",
-    response_model=List[EntityTypeSchema],
+    response_model=Page[EntityTypeSchema],
     summary="List Entity Types",
-    description="Retrieve all entity types representing mythological origins (e.g., Egyptian, Greek, Norse).",
+    description="Retrieve a paginated list of entity types representing mythological origins (e.g., Egyptian, Greek, Norse).",
     responses={
         200: {"description": "Successful retrieval of entity types"},
     },
 )
 async def list_entity_types(
     db: Annotated[Session, Depends(get_db)],
+    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    size: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 20,
     sort: Annotated[
-        str | None, Query(description="Sort field", examples=["name", "id"])
+        Literal["name", "id"],
+        Query(description="Sort field", examples=["name", "id"]),
     ] = "name",
     order: Annotated[
         str, Query(description="Sort order (asc, desc)", examples=["asc", "desc"])
     ] = "asc",
 ):
-    """List all entity types."""
-    entity_types = db.query(EntityType).all()
-
-    # Sort results
-    if order.lower() == "desc":
-        return sorted(entity_types, key=lambda x: getattr(x, sort, x.id), reverse=True)
-    return sorted(entity_types, key=lambda x: getattr(x, sort, x.id))
+    """List all entity types, paginated and sorted at the database level."""
+    sort_column = getattr(EntityType, sort)
+    stmt = select(EntityType).order_by(
+        sort_column.desc() if order.lower() == "desc" else sort_column.asc()
+    )
+    return paginate(db, stmt, Params(page=page, size=size))
 
 
 @router.get(

--- a/app/api/v1/entities/endpoints/locations.py
+++ b/app/api/v1/entities/endpoints/locations.py
@@ -1,6 +1,9 @@
 from typing import Annotated, List
 
 from fastapi import APIRouter, Depends, Path, Query, HTTPException
+from fastapi_pagination import Page, Params
+from fastapi_pagination.ext.sqlalchemy import paginate
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.v1.shared.deps import get_db
@@ -13,9 +16,9 @@ router = APIRouter(prefix="/locations", tags=["locations"])
 
 @router.get(
     "/",
-    response_model=List[LocationSchema],
+    response_model=Page[LocationSchema],
     summary="List Locations",
-    description="Retrieve all locations, optionally filtered by department.",
+    description="Retrieve a paginated list of locations, optionally filtered by department.",
     responses={
         200: {"description": "Successful retrieval of locations"},
     },
@@ -30,11 +33,36 @@ async def list_locations(
             examples=["Cundinamarca", "Oaxaca"],
         ),
     ] = None,
+    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    size: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 20,
 ):
-    """List all locations, optionally filtered by department."""
+    """List all locations, optionally filtered by department, paginated at the database level."""
+    stmt = select(Location)
     if department:
-        return location.get_by_department(db, department=department)
-    return db.query(Location).all()
+        stmt = stmt.where(Location.department.ilike(f"%{department}%"))
+    stmt = stmt.order_by(Location.id)
+    return paginate(db, stmt, Params(page=page, size=size))
+
+
+@router.get(
+    "/{id:int}",
+    response_model=LocationSchema,
+    summary="Get Location",
+    description="Retrieve a specific location by ID.",
+    responses={
+        200: {"description": "Successful retrieval of location"},
+        404: {"description": "Location not found"},
+    },
+)
+async def get_location(
+    db: Annotated[Session, Depends(get_db)],
+    id: Annotated[int, Path(gt=0, description="Location ID", examples=[1])],
+):
+    """Get location by ID."""
+    db_location = location.get(db, item_id=id)
+    if not db_location:
+        raise HTTPException(status_code=404, detail="Location not found")
+    return db_location
 
 
 @router.get(

--- a/app/api/v1/entities/endpoints/sources.py
+++ b/app/api/v1/entities/endpoints/sources.py
@@ -1,10 +1,12 @@
-from typing import Annotated, List
+from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Depends, Query
+from fastapi_pagination import Page, Params
+from fastapi_pagination.ext.sqlalchemy import paginate
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.v1.shared.deps import get_db
-from app.api.v1.entities.services import source
 from app.api.v1.entities.models.source import Source
 from app.api.v1.entities.schemas.source import Source as SourceSchema
 from app.api.v1.entities.enums import SourceType
@@ -14,9 +16,9 @@ router = APIRouter(prefix="/sources", tags=["sources"])
 
 @router.get(
     "/",
-    response_model=List[SourceSchema],
+    response_model=Page[SourceSchema],
     summary="List Sources",
-    description="Retrieve all sources, optionally filtered by type and sorted.",
+    description="Retrieve a paginated list of sources, optionally filtered by type and sorted.",
     responses={
         200: {"description": "Successful retrieval of sources"},
     },
@@ -30,20 +32,23 @@ async def list_sources(
             examples=["Book", "Website", "Manuscript", "Oral Tradition"],
         ),
     ] = None,
+    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+    size: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 20,
     sort: Annotated[
-        str | None, Query(description="Sort field", examples=["title", "author", "id"])
-    ] = "name",
+        Literal["id", "title", "author", "source_type"],
+        Query(description="Sort field", examples=["title", "author", "id"]),
+    ] = "id",
     order: Annotated[
         str, Query(description="Sort order (asc, desc)", examples=["asc", "desc"])
     ] = "asc",
 ):
-    """List all sources, optionally filtered by type and sorted."""
-    query = db.query(Source)
+    """List all sources, optionally filtered by type, paginated and sorted at the database level."""
+    stmt = select(Source)
     if source_type:
-        query = query.filter(Source.source_type == source_type)
-    sources = query.all()
+        stmt = stmt.where(Source.source_type == source_type)
 
-    # Sort results
-    if order.lower() == "desc":
-        return sorted(sources, key=lambda x: getattr(x, sort, x.id), reverse=True)
-    return sorted(sources, key=lambda x: getattr(x, sort, x.id))
+    sort_column = getattr(Source, sort)
+    stmt = stmt.order_by(
+        sort_column.desc() if order.lower() == "desc" else sort_column.asc()
+    )
+    return paginate(db, stmt, Params(page=page, size=size))

--- a/app/api/v1/entities/services/entity.py
+++ b/app/api/v1/entities/services/entity.py
@@ -2,6 +2,9 @@ from sqlalchemy import select, or_, and_
 from sqlalchemy.orm import Session, selectinload
 from sqlalchemy.sql import Select
 
+from fastapi_pagination.bases import AbstractPage, AbstractParams
+from fastapi_pagination.ext.sqlalchemy import paginate as paginate_sqlalchemy
+
 from app.api.common.services.base_service import CRUDBaseService
 from app.api.v1.entities.models.entity import Entity
 from app.api.v1.entities.models.entity_relation import EntityRelation
@@ -27,6 +30,27 @@ class EntityService(CRUDBaseService[Entity, EntityCreate, EntityUpdate]):
         stmt = self._get_base_query().where(Entity.id == item_id)
         return db.execute(stmt).scalar_one_or_none()
 
+    def _apply_filters(
+        self,
+        stmt: Select,
+        *,
+        entity_type: EntityTypeName | None = None,
+        category: CategoryName | None = None,
+        is_active: bool | None = True,
+    ) -> Select:
+        """Apply the common entity_type/category/is_active filters to a query."""
+        filters = []
+        if entity_type:
+            filters.append(Entity.entity_type.has(name=entity_type))
+        if category:
+            filters.append(Entity.category.has(name=category))
+        if is_active is not None:
+            filters.append(Entity.is_active == is_active)
+
+        if filters:
+            stmt = stmt.where(and_(*filters))
+        return stmt
+
     def get_multi(
         self,
         db: Session,
@@ -38,22 +62,45 @@ class EntityService(CRUDBaseService[Entity, EntityCreate, EntityUpdate]):
         limit: int = 100,
     ) -> list[Entity]:
         """Get multiple entities with filters"""
-        stmt = self._get_base_query()
-
-        # Apply filters
-        filters = []
-        if entity_type:
-            filters.append(Entity.entity_type.has(name=entity_type))
-        if category:
-            filters.append(Entity.category.has(name=category))
-        if is_active is not None:
-            filters.append(Entity.is_active == is_active)
-
-        if filters:
-            stmt = stmt.where(and_(*filters))
-
-        stmt = stmt.offset(skip).limit(limit)
+        stmt = self._apply_filters(
+            self._get_base_query(),
+            entity_type=entity_type,
+            category=category,
+            is_active=is_active,
+        )
+        stmt = stmt.order_by(Entity.id).offset(skip).limit(limit)
         return db.execute(stmt).scalars().all()
+
+    def get_paginated(
+        self,
+        db: Session,
+        *,
+        entity_type: EntityTypeName | None = None,
+        category: CategoryName | None = None,
+        is_active: bool | None = True,
+        params: AbstractParams | None = None,
+    ) -> AbstractPage:
+        """Get entities with filters, paginated at the DB level.
+
+        Unlike `get_multi`, this performs a real SQL COUNT + LIMIT/OFFSET via
+        fastapi-pagination's SQLAlchemy extension, instead of slicing an
+        already-limited Python list a second time (see the double-pagination
+        bug this replaces in the `list_entities` endpoint).
+
+        `params` should be the `Params(page=page, size=size)` built from the
+        endpoint's own page/size query params — the endpoint also validates
+        entity_type/category/is_active, so it can't rely on fastapi-
+        pagination's auto-injected Params context (that would silently apply
+        its own default page size instead of this endpoint's).
+        """
+        stmt = self._apply_filters(
+            self._get_base_query(),
+            entity_type=entity_type,
+            category=category,
+            is_active=is_active,
+        )
+        stmt = stmt.order_by(Entity.id)
+        return paginate_sqlalchemy(db, stmt, params)
 
     def search(self, db: Session, *, term: str) -> list[Entity]:
         """Search entities by name, alternative_names, description, or origin"""

--- a/tests/domains/test_categories.py
+++ b/tests/domains/test_categories.py
@@ -17,7 +17,8 @@ class TestCategoriesEndpoints:
         response = client.get("/api/v1/categories/")
         assert response.status_code == 200
         data = response.json()
-        assert data == []
+        assert data["items"] == []
+        assert data["total"] == 0
 
     def test_list_categories(self, client: TestClient, db: Session):
         """Test listing all categories."""
@@ -32,7 +33,8 @@ class TestCategoriesEndpoints:
         response = client.get("/api/v1/categories/")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 3
+        assert len(data["items"]) == 3
+        assert data["total"] == 3
 
     def test_list_categories_sorted_by_name_asc(self, client: TestClient, db: Session):
         """Test that categories are sorted by name ascending by default."""
@@ -47,7 +49,7 @@ class TestCategoriesEndpoints:
         response = client.get("/api/v1/categories/")
         assert response.status_code == 200
         data = response.json()
-        names = [c["name"] for c in data]
+        names = [c["name"] for c in data["items"]]
         assert names == sorted(names)
 
     def test_list_categories_sorted_desc(self, client: TestClient, db: Session):
@@ -62,7 +64,7 @@ class TestCategoriesEndpoints:
         response = client.get("/api/v1/categories/?order=desc")
         assert response.status_code == 200
         data = response.json()
-        names = [c["name"] for c in data]
+        names = [c["name"] for c in data["items"]]
         assert names == sorted(names, reverse=True)
 
     def test_get_category_by_id(self, client: TestClient, db: Session):

--- a/tests/domains/test_entities.py
+++ b/tests/domains/test_entities.py
@@ -214,13 +214,43 @@ class TestEntitiesEndpoints:
             ))
         db.commit()
 
-        # Endpoint limits results before paginating, so total reflects the limited set
+        # Pagination is real DB-level pagination now: `total` must reflect
+        # the full row count, not just the current page's size.
         response = client.get("/api/v1/entities/?page=1&size=2")
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 2
-        assert data["total"] == 2
+        assert data["total"] == 5
         assert data["page"] == 1
+
+    def test_list_entities_pagination_second_page_returns_remaining_rows(
+        self, client: TestClient, db: Session
+    ):
+        """Regression test for the double-pagination bug: requesting page 2
+        of a multi-page result set used to return an empty `items` list and
+        a `total` equal to the page size (not the real row count), because
+        the endpoint re-paginated a list that the DB query had already
+        sliced to a single page. Page 2 of 45 rows at size=20 must return
+        the 20 remaining rows (21-40) and `total` must be the real count."""
+        deps = self._seed_dependencies(db)
+
+        total_rows = 45
+        for i in range(total_rows):
+            db.add(Entity(
+                name=f"Entity {i:03d}",
+                category_id=deps["category_id"],
+                entity_type_id=deps["entity_type_id"],
+                is_active=True,
+            ))
+        db.commit()
+
+        response = client.get("/api/v1/entities/?page=2&size=20")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == total_rows
+        assert len(data["items"]) > 0
+        assert len(data["items"]) == 20
+        assert data["page"] == 2
 
     def test_list_entities_filter_by_entity_type(self, client: TestClient, db: Session):
         """Test filtering entities by entity_type."""

--- a/tests/domains/test_entity_types.py
+++ b/tests/domains/test_entity_types.py
@@ -17,7 +17,8 @@ class TestEntityTypesEndpoints:
         response = client.get("/api/v1/entity-types/")
         assert response.status_code == 200
         data = response.json()
-        assert data == []
+        assert data["items"] == []
+        assert data["total"] == 0
 
     def test_list_entity_types(self, client: TestClient, db: Session):
         """Test listing all entity types."""
@@ -38,7 +39,8 @@ class TestEntityTypesEndpoints:
         response = client.get("/api/v1/entity-types/")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 3
+        assert len(data["items"]) == 3
+        assert data["total"] == 3
 
     def test_list_entity_types_sorted_by_name_asc(
         self, client: TestClient, db: Session
@@ -55,7 +57,7 @@ class TestEntityTypesEndpoints:
         response = client.get("/api/v1/entity-types/")
         assert response.status_code == 200
         data = response.json()
-        names = [e["name"] for e in data]
+        names = [e["name"] for e in data["items"]]
         assert names == sorted(names)
 
     def test_list_entity_types_sorted_desc(self, client: TestClient, db: Session):
@@ -70,7 +72,7 @@ class TestEntityTypesEndpoints:
         response = client.get("/api/v1/entity-types/?order=desc")
         assert response.status_code == 200
         data = response.json()
-        names = [e["name"] for e in data]
+        names = [e["name"] for e in data["items"]]
         assert names == sorted(names, reverse=True)
 
     def test_get_entity_type_by_id(self, client: TestClient, db: Session):

--- a/tests/domains/test_locations.py
+++ b/tests/domains/test_locations.py
@@ -16,7 +16,8 @@ class TestLocationsEndpoints:
         response = client.get("/api/v1/locations/")
         assert response.status_code == 200
         data = response.json()
-        assert data == []
+        assert data["items"] == []
+        assert data["total"] == 0
 
     def test_list_locations(self, client: TestClient, db: Session):
         """Test listing all locations."""
@@ -40,7 +41,8 @@ class TestLocationsEndpoints:
         response = client.get("/api/v1/locations/")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 2
+        assert len(data["items"]) == 2
+        assert data["total"] == 2
 
     def test_filter_locations_by_department(self, client: TestClient, db: Session):
         """Test filtering locations by department query parameter."""
@@ -62,8 +64,8 @@ class TestLocationsEndpoints:
         response = client.get("/api/v1/locations/?department=Cundinamarca")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 1
-        assert data[0]["department"] == "Cundinamarca"
+        assert len(data["items"]) == 1
+        assert data["items"][0]["department"] == "Cundinamarca"
 
     def test_filter_locations_by_department_partial_match(
         self, client: TestClient, db: Session
@@ -92,7 +94,58 @@ class TestLocationsEndpoints:
         response = client.get("/api/v1/locations/?department=San")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 2
+        assert len(data["items"]) == 2
+        assert data["total"] == 2
+
+    def test_get_location_by_id(self, client: TestClient, db: Session):
+        """Test getting a single location by its numeric ID."""
+        location = Location(
+            entity_id=1,
+            department="Cundinamarca",
+            municipality="Bogota",
+            place_description="Capital city",
+        )
+        db.add(location)
+        db.commit()
+
+        response = client.get(f"/api/v1/locations/{location.id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == location.id
+        assert data["department"] == "Cundinamarca"
+
+    def test_get_location_by_id_not_found(self, client: TestClient):
+        """Test getting a non-existent location by ID returns 404."""
+        response = client.get("/api/v1/locations/999")
+        assert response.status_code == 404
+        data = response.json()
+        assert "detail" in data
+        assert "not found" in data["detail"].lower()
+
+    def test_get_location_by_id_does_not_collide_with_department_route(
+        self, client: TestClient, db: Session
+    ):
+        """A numeric ID path segment must resolve via the /{id} route, not be
+        swallowed by the string-typed /{department} route."""
+        department_only = Location(
+            entity_id=1,
+            department="42",
+            municipality="Numeric Department",
+        )
+        real_location = Location(
+            entity_id=1,
+            department="Cundinamarca",
+        )
+        db.add_all([department_only, real_location])
+        db.commit()
+
+        # Request by the real location's numeric ID should return a single
+        # object (LocationSchema), not a list from the department route.
+        response = client.get(f"/api/v1/locations/{real_location.id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+        assert data["id"] == real_location.id
 
     def test_get_locations_by_department_path(self, client: TestClient, db: Session):
         """Test getting locations by department via path parameter."""
@@ -145,7 +198,7 @@ class TestLocationsEndpoints:
         response = client.get("/api/v1/locations/")
         assert response.status_code == 200
         data = response.json()
-        loc = data[0]
+        loc = data["items"][0]
         assert "id" in loc
         assert "entity_id" in loc
         assert "department" in loc

--- a/tests/domains/test_sources.py
+++ b/tests/domains/test_sources.py
@@ -17,7 +17,8 @@ class TestSourcesEndpoints:
         response = client.get("/api/v1/sources/")
         assert response.status_code == 200
         data = response.json()
-        assert data == []
+        assert data["items"] == []
+        assert data["total"] == 0
 
     def test_list_sources(self, client: TestClient, db: Session):
         """Test listing all sources."""
@@ -43,7 +44,8 @@ class TestSourcesEndpoints:
         response = client.get("/api/v1/sources/")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 2
+        assert len(data["items"]) == 2
+        assert data["total"] == 2
 
     def test_list_sources_sorted_by_title(self, client: TestClient, db: Session):
         """Test sorting sources by title field."""
@@ -54,13 +56,19 @@ class TestSourcesEndpoints:
         db.add_all(sources)
         db.commit()
 
-        # Source model has no 'name' field, so default sort falls back to 'id'
+        # Source model has no 'name' field, so default sort is 'id'.
         # Explicitly sort by 'title' to test title-based ordering
         response = client.get("/api/v1/sources/?sort=title")
         assert response.status_code == 200
         data = response.json()
-        titles = [s["title"] for s in data]
+        titles = [s["title"] for s in data["items"]]
         assert titles == sorted(titles)
+
+    def test_list_sources_invalid_sort_field_rejected(self, client: TestClient):
+        """Test that an invalid sort field is rejected with a 422, rather than
+        silently falling back to id like the old, unvalidated implementation."""
+        response = client.get("/api/v1/sources/?sort=not_a_real_field")
+        assert response.status_code == 422
 
     def test_list_sources_sorted_desc(self, client: TestClient, db: Session):
         """Test listing sources sorted descending."""
@@ -74,7 +82,7 @@ class TestSourcesEndpoints:
         response = client.get("/api/v1/sources/?order=desc")
         assert response.status_code == 200
         data = response.json()
-        titles = [s["title"] for s in data]
+        titles = [s["title"] for s in data["items"]]
         assert titles == sorted(titles, reverse=True)
 
     def test_filter_sources_by_type(self, client: TestClient, db: Session):
@@ -102,8 +110,8 @@ class TestSourcesEndpoints:
         response = client.get("/api/v1/sources/?source_type=BOOK")
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 1
-        assert data[0]["source_type"] == "BOOK"
+        assert len(data["items"]) == 1
+        assert data["items"][0]["source_type"] == "BOOK"
 
     def test_source_response_schema(self, client: TestClient, db: Session):
         """Test that source response matches expected schema."""
@@ -120,7 +128,7 @@ class TestSourcesEndpoints:
         response = client.get("/api/v1/sources/")
         assert response.status_code == 200
         data = response.json()
-        s = data[0]
+        s = data["items"][0]
         assert "id" in s
         assert "entity_id" in s
         assert "source_type" in s

--- a/tests/domains/test_users.py
+++ b/tests/domains/test_users.py
@@ -242,6 +242,37 @@ class TestUsersEndpoints:
         assert data["total"] == 3
         assert len(data["items"]) == 3
 
+    def test_get_all_users_second_page_returns_remaining_rows(
+        self, client: TestClient, db: Session, superuser_headers: dict
+    ):
+        """Regression test for the double-pagination bug: page 2 of a
+        multi-page user list used to come back empty with `total` equal to
+        the page size, because `get_multi(skip, limit)` had already sliced
+        the DB rows down to one page before `paginate()` re-sliced them a
+        second time using the same page number."""
+        # 24 extra users + 1 superuser (created by the `superuser_headers`
+        # fixture) = 25 total rows, spanning 2 pages at size=20.
+        users = [
+            User(
+                email=f"user{i}@example.com",
+                hashed_password="hashed",
+                full_name=f"User {i}",
+            )
+            for i in range(24)
+        ]
+        db.add_all(users)
+        db.commit()
+
+        response = client.get(
+            "/api/v1/users/?page=2&size=20", headers=superuser_headers
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 25
+        assert len(data["items"]) > 0
+        assert len(data["items"]) == 5
+        assert data["page"] == 2
+
     def test_create_user(self, client: TestClient, superuser_headers: dict):
         """Test creating a user as superuser."""
         response = client.post(


### PR DESCRIPTION
## Summary

1. **Critical, verified live before fixing** — `/entities/` and `/users/` list endpoints double-paginated: the DB query already sliced to one page (`skip`/`limit`), then `fastapi_pagination.paginate()` re-sliced that already-sliced list using the same page number. Page 2+ silently returned an empty `items` list and a wrong `total` (page size instead of real row count). Fixed by using DB-level pagination (`fastapi_pagination.ext.sqlalchemy.paginate`) throughout, plus added `ORDER BY` before offset/limit (a second bug: unstable pagination without one).
2. `categories`/`entity_types`/`sources` bypassed the service layer entirely (`db.query(Model).all()`, legacy SQLAlchemy 1.x style), loaded the *entire* table on every request with no pagination, and sorted in Python via an **unvalidated** `sort` param that silently fell back to `id` on any bad input. Rewritten to `select()` + DB-level `ORDER BY`/pagination, with `sort` now a `Literal[...]` of real columns (422 on invalid input instead of silent fallback).
3. `locations` broke the API's own resource convention — no `GET /locations/{id}`, only a `GET /locations/{department}` duplicating the `?department=` filter. Added a proper `GET /locations/{id:int}`, using Starlette's int path converter so it doesn't collide with the department route.
4. Removed a dead `JsonApiPage` import in `users.py` (imported but never used).

## Verification
Independently re-ran the full suite against a fresh Postgres 15 container: **163/163 pass** (up from 157 — 6 new tests, including a direct regression test seeding 45 entities and confirming page 2 returns the real remaining rows with the correct total). `flake8`/`black` clean.