### PR TITLE
fix: FastAPI idiom issues (middleware order, blocking event loop, blocking email)

### DIFF
--- a/app/api/v1/domains/auth/endpoints/auth.py
+++ b/app/api/v1/domains/auth/endpoints/auth.py
@@ -89,7 +89,7 @@ class PasswordReset(BaseModel):
     },
 )
 @limiter.limit(f"{settings.RATE_LIMIT_AUTH_PER_MINUTE}/minute")
-async def login_access_token(
+def login_access_token(
     request: Request,
     db: Session = Depends(get_db),
     form_data: OAuth2PasswordRequestForm = Depends(),
@@ -131,7 +131,7 @@ async def login_access_token(
         401: {"description": "Unauthorized - No valid token provided"},
     },
 )
-async def get_current_user_info(
+def get_current_user_info(
     current_user: UserModel = Depends(get_current_user),
 ) -> UserModel:
     """Get current user information."""
@@ -147,7 +147,7 @@ async def get_current_user_info(
     },
 )
 @limiter.limit(f"{settings.RATE_LIMIT_AUTH_PER_MINUTE}/minute")
-async def recover_password(
+def recover_password(
     request: Request,
     background_tasks: BackgroundTasks,
     email: str = Path(
@@ -189,7 +189,7 @@ async def recover_password(
     },
 )
 @limiter.limit(f"{settings.RATE_LIMIT_AUTH_PER_MINUTE}/minute")
-async def reset_password(
+def reset_password(
     request: Request,
     password_reset: PasswordReset,
     db: Session = Depends(get_db),

--- a/app/api/v1/domains/auth/endpoints/auth.py
+++ b/app/api/v1/domains/auth/endpoints/auth.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -149,6 +149,7 @@ async def get_current_user_info(
 @limiter.limit(f"{settings.RATE_LIMIT_AUTH_PER_MINUTE}/minute")
 async def recover_password(
     request: Request,
+    background_tasks: BackgroundTasks,
     email: str = Path(
         ..., description="User email address", examples=["user@example.com"]
     ),
@@ -165,8 +166,11 @@ async def recover_password(
 
     if user:
         password_reset_token = generate_password_reset_token(email=email)
-        send_reset_password_email(
-            email_to=user.email, email=email, token=password_reset_token
+        background_tasks.add_task(
+            send_reset_password_email,
+            email_to=user.email,
+            email=email,
+            token=password_reset_token,
         )
 
     return {

--- a/app/api/v1/domains/countries/endpoints/countries.py
+++ b/app/api/v1/domains/countries/endpoints/countries.py
@@ -25,7 +25,7 @@ router = APIRouter()
         200: {"description": "Successful retrieval of countries"},
     },
 )
-async def list_countries(
+def list_countries(
     *,
     db: Session = Depends(get_db),
     relations: str | None = Query(
@@ -63,7 +63,7 @@ async def list_countries(
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def add_country(
+def add_country(
     db: Session = Depends(get_db),
     country: CountryCreate = Body(
         ...,
@@ -87,7 +87,7 @@ async def add_country(
         404: {"description": "Country not found"},
     },
 )
-async def get_country(
+def get_country(
     *,
     db: Session = Depends(get_db),
     country_id: int = Path(..., description="Country ID", examples=[1], gt=0),
@@ -120,7 +120,7 @@ async def get_country(
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def update_country(
+def update_country(
     *,
     db: Session = Depends(get_db),
     country_id: int = Path(..., description="Country ID", examples=[1], gt=0),
@@ -149,7 +149,7 @@ async def update_country(
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def delete_country(
+def delete_country(
     *,
     db: Session = Depends(get_db),
     country_id: int = Path(..., description="Country ID", examples=[1], gt=0),

--- a/app/api/v1/domains/health/endpoints/health.py
+++ b/app/api/v1/domains/health/endpoints/health.py
@@ -35,7 +35,7 @@ router = APIRouter(prefix="/health", tags=["health"])
         200: {"description": "Service is healthy"},
     },
 )
-async def health_check() -> dict[str, Any]:
+def health_check() -> dict[str, Any]:
     """
     Basic health check endpoint.
 
@@ -56,7 +56,7 @@ async def health_check() -> dict[str, Any]:
         200: {"description": "Service is alive"},
     },
 )
-async def liveness_probe() -> dict[str, Any]:
+def liveness_probe() -> dict[str, Any]:
     """
     Liveness probe endpoint.
 
@@ -80,7 +80,7 @@ async def liveness_probe() -> dict[str, Any]:
     },
     status_code=status.HTTP_200_OK,
 )
-async def readiness_probe(
+def readiness_probe(
     db: Session = Depends(get_db),
 ) -> dict[str, Any]:
     """

--- a/app/api/v1/domains/images/endpoints/images.py
+++ b/app/api/v1/domains/images/endpoints/images.py
@@ -18,7 +18,7 @@ ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg"}
         404: {"description": "Image not found"},
     },
 )
-async def get_file(name_file: str):
+def get_file(name_file: str):
     """
     Serve image files from the /app/images/ directory.
 

--- a/app/api/v1/domains/users/endpoints/users.py
+++ b/app/api/v1/domains/users/endpoints/users.py
@@ -27,7 +27,7 @@ router = APIRouter()
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def get_users(
+def get_users(
     db: Session = Depends(get_db),
     page: int = Query(1, description="Page number", ge=1),
     size: int = Query(20, description="Items per page", ge=1, le=100),
@@ -56,7 +56,7 @@ async def get_users(
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def create_user(
+def create_user(
     *,
     db: Session = Depends(get_db),
     user_in: UserCreate,
@@ -85,7 +85,7 @@ async def create_user(
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def update_user(
+def update_user(
     *,
     db: Session = Depends(get_db),
     user_id: int = Path(..., description="User ID", examples=[1], gt=0),
@@ -112,7 +112,7 @@ async def update_user(
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def get_user(
+def get_user(
     *,
     db: Session = Depends(get_db),
     user_id: int = Path(..., description="User ID", examples=[1], gt=0),
@@ -137,7 +137,7 @@ async def get_user(
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def delete_user(
+def delete_user(
     *,
     db: Session = Depends(get_db),
     user_id: int = Path(..., description="User ID", examples=[1], gt=0),

--- a/app/api/v1/entities/endpoints/categories.py
+++ b/app/api/v1/entities/endpoints/categories.py
@@ -23,7 +23,7 @@ router = APIRouter(prefix="/categories", tags=["categories"])
         200: {"description": "Successful retrieval of categories"},
     },
 )
-async def list_categories(
+def list_categories(
     db: Annotated[Session, Depends(get_db)],
     page: Annotated[int, Query(ge=1, description="Page number")] = 1,
     size: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 20,
@@ -53,7 +53,7 @@ async def list_categories(
         404: {"description": "Category not found"},
     },
 )
-async def get_category(
+def get_category(
     db: Annotated[Session, Depends(get_db)],
     id: Annotated[int, Path(gt=0, description="Category ID", examples=[1])],
 ):

--- a/app/api/v1/entities/endpoints/entities.py
+++ b/app/api/v1/entities/endpoints/entities.py
@@ -26,7 +26,7 @@ router = APIRouter(prefix="/entities", tags=["entities"])
         200: {"description": "Successful retrieval of entities"},
     },
 )
-async def list_entities(
+def list_entities(
     db: Annotated[Session, Depends(get_db)],
     entity_type: Annotated[
         EntityTypeName | None,
@@ -69,7 +69,7 @@ async def list_entities(
         200: {"description": "Successful search results"},
     },
 )
-async def search_entities(
+def search_entities(
     db: Annotated[Session, Depends(get_db)],
     q: Annotated[
         str,
@@ -95,7 +95,7 @@ async def search_entities(
         404: {"description": "Entity not found"},
     },
 )
-async def get_entity(
+def get_entity(
     db: Annotated[Session, Depends(get_db)],
     id: Annotated[int, Path(gt=0, description="Entity ID", examples=[1])],
 ):
@@ -166,7 +166,7 @@ async def get_entity(
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def create_entity(
+def create_entity(
     db: Annotated[Session, Depends(get_db)],
     entity_in: EntityCreate,
     current_user: UserModel = Depends(get_current_active_superuser),
@@ -187,7 +187,7 @@ async def create_entity(
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def update_entity(
+def update_entity(
     db: Annotated[Session, Depends(get_db)],
     id: Annotated[int, Path(gt=0, description="Entity ID", examples=[1])],
     entity_in: EntityUpdate,
@@ -212,7 +212,7 @@ async def update_entity(
         403: {"description": "Forbidden - User is not a superuser"},
     },
 )
-async def delete_entity(
+def delete_entity(
     db: Annotated[Session, Depends(get_db)],
     id: Annotated[int, Path(gt=0, description="Entity ID", examples=[1])],
     current_user: UserModel = Depends(get_current_active_superuser),
@@ -234,7 +234,7 @@ async def delete_entity(
         404: {"description": "Entity not found"},
     },
 )
-async def get_entity_relations(
+def get_entity_relations(
     db: Annotated[Session, Depends(get_db)],
     id: Annotated[int, Path(gt=0, description="Entity ID", examples=[1])],
 ):

--- a/app/api/v1/entities/endpoints/entity_types.py
+++ b/app/api/v1/entities/endpoints/entity_types.py
@@ -23,7 +23,7 @@ router = APIRouter(prefix="/entity-types", tags=["entity-types"])
         200: {"description": "Successful retrieval of entity types"},
     },
 )
-async def list_entity_types(
+def list_entity_types(
     db: Annotated[Session, Depends(get_db)],
     page: Annotated[int, Query(ge=1, description="Page number")] = 1,
     size: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 20,
@@ -53,7 +53,7 @@ async def list_entity_types(
         404: {"description": "Entity type not found"},
     },
 )
-async def get_entity_type(
+def get_entity_type(
     db: Annotated[Session, Depends(get_db)],
     id: Annotated[int, Path(gt=0, description="Entity Type ID", examples=[1])],
 ):

--- a/app/api/v1/entities/endpoints/locations.py
+++ b/app/api/v1/entities/endpoints/locations.py
@@ -23,7 +23,7 @@ router = APIRouter(prefix="/locations", tags=["locations"])
         200: {"description": "Successful retrieval of locations"},
     },
 )
-async def list_locations(
+def list_locations(
     db: Annotated[Session, Depends(get_db)],
     department: Annotated[
         str | None,
@@ -54,7 +54,7 @@ async def list_locations(
         404: {"description": "Location not found"},
     },
 )
-async def get_location(
+def get_location(
     db: Annotated[Session, Depends(get_db)],
     id: Annotated[int, Path(gt=0, description="Location ID", examples=[1])],
 ):
@@ -74,7 +74,7 @@ async def get_location(
         200: {"description": "Successful retrieval of locations"},
     },
 )
-async def get_location_by_department(
+def get_location_by_department(
     db: Annotated[Session, Depends(get_db)],
     department: Annotated[
         str,

--- a/app/api/v1/entities/endpoints/sources.py
+++ b/app/api/v1/entities/endpoints/sources.py
@@ -23,7 +23,7 @@ router = APIRouter(prefix="/sources", tags=["sources"])
         200: {"description": "Successful retrieval of sources"},
     },
 )
-async def list_sources(
+def list_sources(
     db: Annotated[Session, Depends(get_db)],
     source_type: Annotated[
         SourceType | None,

--- a/app/main.py
+++ b/app/main.py
@@ -8,9 +8,6 @@ from fastapi.openapi.docs import get_swagger_ui_html
 from app.api.common.exceptions.api_exception import add_exception_handler
 from app.api.common.middleware import SecurityHeadersMiddleware, RequestIDMiddleware
 from app.api.common.middleware.rate_limiter import setup_rate_limiter
-from app.api.common.middleware.request_id import (
-    RequestIDMiddleware as LoggingMiddleware,
-)
 from app.api.v1.router import api_router
 from app.core.config import settings
 from app.core.logging_config import setup_logging, LoggingMiddleware

--- a/app/main.py
+++ b/app/main.py
@@ -64,16 +64,26 @@ Admin endpoints (create, update, delete) are documented at `/admin/docs` (requir
     },
 )
 
-# Request ID (must be first to capture all requests)
-app.add_middleware(RequestIDMiddleware)
+# Starlette's add_middleware() inserts each new middleware at the FRONT of the
+# user_middleware list, and build_middleware_stack() wraps that list in
+# reversed order — so the LAST middleware registered ends up OUTERMOST and
+# runs FIRST on the way in (closest to the client), while the FIRST middleware
+# registered ends up INNERMOST and runs LAST on the way in (closest to the
+# route). Actual execution order on a request, given the registrations below,
+# is: CORS -> SecurityHeaders -> RequestID -> Logging -> route.
 
-# Structured logging (after RequestID to capture request_id)
+# Structured logging (innermost of this group; registered first so it runs
+# last on the way in, after RequestID has set request.state.request_id)
 app.add_middleware(LoggingMiddleware)
+
+# Request ID (registered after Logging so it runs before Logging on the way
+# in, ensuring request.state.request_id is set before Logging reads it)
+app.add_middleware(RequestIDMiddleware)
 
 # Security headers
 app.add_middleware(SecurityHeadersMiddleware)
 
-# Set all CORS enabled
+# Set all CORS enabled (registered last so it runs first / outermost)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[str(origin) for origin in settings.BACKEND_CORS_ORIGINS],

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,59 @@
+"""
+Tests for middleware ordering (request_id + structured logging).
+
+Regression test for a bug where RequestIDMiddleware and LoggingMiddleware
+were registered in the wrong order in app/main.py. Starlette's
+add_middleware() prepends to the middleware stack, so the LAST middleware
+registered ends up OUTERMOST and runs FIRST on the way in. With the buggy
+order, LoggingMiddleware read request.state.request_id before
+RequestIDMiddleware had set it, so every structured log line had
+request_id="unknown".
+"""
+
+import logging
+
+from fastapi.testclient import TestClient
+
+
+class TestRequestIdLoggingOrder:
+    """Verify RequestIDMiddleware runs before LoggingMiddleware."""
+
+    def test_response_has_request_id_header(self, client: TestClient):
+        """The X-Request-ID response header should always be present and non-empty."""
+        response = client.get("/api/v1/health")
+        assert response.status_code == 200
+        request_id = response.headers.get("X-Request-ID")
+        assert request_id
+        assert len(request_id) > 0
+
+    def test_logged_request_id_matches_response_header(
+        self, client: TestClient, caplog
+    ):
+        """
+        The request_id captured in the structured log for a request must match
+        the X-Request-ID returned in that same request's response header.
+
+        If middleware ordering regresses (Logging registered after RequestID,
+        i.e. Logging ends up innermost/reads state first), this fails because
+        the log record's request_id falls back to "unknown" while the response
+        header still carries a real UUID.
+        """
+        with caplog.at_level(logging.INFO, logger="api.requests"):
+            response = client.get("/api/v1/health")
+
+        assert response.status_code == 200
+        response_request_id = response.headers.get("X-Request-ID")
+        assert response_request_id
+
+        matching_records = [
+            record
+            for record in caplog.records
+            if record.name == "api.requests"
+            and getattr(record, "path", None) == "/api/v1/health"
+        ]
+        assert matching_records, "expected LoggingMiddleware to emit a log record"
+
+        logged_request_id = getattr(matching_records[-1], "request_id", None)
+        assert logged_request_id is not None
+        assert logged_request_id != "unknown"
+        assert logged_request_id == response_request_id


### PR DESCRIPTION
## Summary

1. **Critical, verified against Starlette source** — middleware was registered in an order that put `LoggingMiddleware` before `RequestIDMiddleware` in actual execution (Starlette's `add_middleware` inserts at front + wraps in reverse order, so last-registered = outermost = runs first — the reverse of registration order). Every structured log line showed `request_id: unknown`. Fixed by swapping registration order; verified by manually re-tracing the Starlette logic myself before merging.
2. Removed a dead, shadowed import in `main.py` (`RequestIDMiddleware as LoggingMiddleware`, silently overwritten by the real `LoggingMiddleware` import two lines later).
3. **All 33 endpoint functions** declared `async def` while doing fully synchronous DB calls (plain `Session`, not `AsyncSession`) — FastAPI only threadpools plain `def` endpoints, so every one of these was blocking the event loop directly on every DB call. Confirmed zero `await` expressions exist anywhere in any endpoint body before converting; all 33 converted to plain `def`.
4. Password-recovery email send was blocking the request/response cycle — moved to `BackgroundTasks`.

## Verification
Independently re-ran the full suite: **165/165 pass** (up from 163 — new middleware-order regression test using `caplog` confirms `request_id` in a log record now matches the response's `X-Request-ID` header). `flake8`/`black` clean. Manually re-traced Starlette's middleware wrapping logic myself (not just trusting the fix) before approving.