### PR TITLE
fix: DB/schema improvements (pool settings, redundant indexes, N+1, wasteful fetch)

### DIFF
--- a/alembic/versions/afdd04d1e09b_drop_redundant_entity_relation_indexes.py
+++ b/alembic/versions/afdd04d1e09b_drop_redundant_entity_relation_indexes.py
@@ -1,0 +1,46 @@
+"""drop redundant entity_relation indexes
+
+Revision ID: afdd04d1e09b
+Revises: bd728d1bc3f7
+Create Date: 2026-07-16 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'afdd04d1e09b'
+down_revision = 'bd728d1bc3f7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # entity_relation had two indexes per column: the auto-generated
+    # ix_entity_relation_entity_origin_id/ix_entity_relation_entity_destination_id
+    # (from `index=True` on the mapped_column) duplicated the named
+    # ix_entity_relation_origin/ix_entity_relation_destination indexes below.
+    # Postgres only ever uses one of two identical indexes per column, so the
+    # duplicates were pure write amplification. Keep the named ones, drop these.
+    op.drop_index(
+        op.f('ix_entity_relation_entity_origin_id'), table_name='entity_relation'
+    )
+    op.drop_index(
+        op.f('ix_entity_relation_entity_destination_id'), table_name='entity_relation'
+    )
+
+
+def downgrade():
+    op.create_index(
+        op.f('ix_entity_relation_entity_destination_id'),
+        'entity_relation',
+        ['entity_destination_id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_entity_relation_entity_origin_id'),
+        'entity_relation',
+        ['entity_origin_id'],
+        unique=False,
+    )

--- a/app/api/common/services/base_service.py
+++ b/app/api/common/services/base_service.py
@@ -132,3 +132,8 @@ class CRUDBaseService(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
     def validate_existence(self, db: Session, *, item_id: int) -> Optional[ModelType]:
         """Validate that an item exists by ID."""
         return self.get(db, item_id=item_id)
+
+    def exists(self, db: Session, *, item_id: int) -> bool:
+        """Check whether a row with this ID exists, without fetching or eager-loading it."""
+        stmt = select(self.model.id).where(self.model.id == item_id)
+        return db.execute(stmt).scalar_one_or_none() is not None

--- a/app/api/v1/entities/endpoints/entities.py
+++ b/app/api/v1/entities/endpoints/entities.py
@@ -239,8 +239,7 @@ def get_entity_relations(
     id: Annotated[int, Path(gt=0, description="Entity ID", examples=[1])],
 ):
     """Get all relations for an entity."""
-    db_entity = entity.get(db, item_id=id)
-    if not db_entity:
+    if not entity.exists(db, item_id=id):
         raise HTTPException(status_code=404, detail="Entity not found")
 
     relations = relation.get_by_entity(db, entity_id=id)

--- a/app/api/v1/entities/models/entity_relation.py
+++ b/app/api/v1/entities/models/entity_relation.py
@@ -15,10 +15,10 @@ class EntityRelation(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True, index=True)
     entity_origin_id: Mapped[int] = mapped_column(
-        ForeignKey("entity.id", ondelete="CASCADE"), nullable=False, index=True
+        ForeignKey("entity.id", ondelete="CASCADE"), nullable=False
     )
     entity_destination_id: Mapped[int] = mapped_column(
-        ForeignKey("entity.id", ondelete="CASCADE"), nullable=False, index=True
+        ForeignKey("entity.id", ondelete="CASCADE"), nullable=False
     )
     relation_type: Mapped[RelationType] = mapped_column(String(50), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/app/api/v1/entities/services/entity_relation.py
+++ b/app/api/v1/entities/services/entity_relation.py
@@ -1,5 +1,5 @@
 from sqlalchemy import select, or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.api.common.services.base_service import CRUDBaseService
 from app.api.v1.entities.models.entity_relation import EntityRelation, RelationType
@@ -15,11 +15,21 @@ class EntityRelationService(
     """Service for EntityRelation CRUD operations."""
 
     def get_by_entity(self, db: Session, *, entity_id: int) -> list[EntityRelation]:
-        """Get all relations for an entity (both directions)"""
-        stmt = select(EntityRelation).where(
-            or_(
-                EntityRelation.entity_origin_id == entity_id,
-                EntityRelation.entity_destination_id == entity_id,
+        """Get all relations for an entity (both directions), eager-loading
+        entity_origin/entity_destination to avoid an N+1 when callers access
+        the related entity for every relation (see EntityService.get_relations_graph
+        for the same eager-loading shape)."""
+        stmt = (
+            select(EntityRelation)
+            .where(
+                or_(
+                    EntityRelation.entity_origin_id == entity_id,
+                    EntityRelation.entity_destination_id == entity_id,
+                )
+            )
+            .options(
+                selectinload(EntityRelation.entity_origin),
+                selectinload(EntityRelation.entity_destination),
             )
         )
         return db.execute(stmt).scalars().all()

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -3,5 +3,16 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from app.core.config import settings
 
-engine = create_engine(str(settings.SQLALCHEMY_DATABASE_URI), pool_pre_ping=True)
+# Explicit pool sizing (not magic numbers): this deploys to a small,
+# resource-constrained VPS (~8GB RAM shared with ~20 other containers,
+# single Postgres instance, single uvicorn worker), so pool_size + max_overflow
+# are deliberately kept modest, and pool_recycle guards against stale
+# connections after any Postgres-side idle-connection reaping.
+engine = create_engine(
+    str(settings.SQLALCHEMY_DATABASE_URI),
+    pool_pre_ping=True,
+    pool_size=5,
+    max_overflow=5,
+    pool_recycle=1800,
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
## Summary

1. Explicit connection pool settings (`pool_size=5, max_overflow=5, pool_recycle=1800`) for the target VPS scale — previously all implicit defaults.
2. `entity_relation` had 4 indexes covering just 2 columns (auto-generated `index=True` duplicating explicitly-named `Index(...)` entries) — pure write amplification, no read benefit. New migration drops the redundant pair.
3. `EntityRelationService.get_by_entity` didn't eager-load `entity_origin`/`entity_destination`, causing a real N+1 in `GET /entities/{id}/relations` (one extra query per relation). Now matches `EntityService.get_relations_graph`'s eager-loading.
4. `get_entity_relations` used a full eager-loaded `entity.get()` (5 `selectinload`s) purely to check existence. Added a lightweight `CRUDBaseService.exists()` and switched this one call site to it.

## Verification
- New migration's up/down/up cycle tested against a **fresh** Postgres 15 container from scratch (full 9-migration chain applies cleanly, including the new one).
- Full suite independently re-run: **165/165 pass**, 82.8% coverage. `flake8`/`black` clean.